### PR TITLE
Fix: Add setValue method in monaco-adapter

### DIFF
--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -216,7 +216,7 @@ firepad.Firepad = (function(global) {
   Firepad.prototype.setText = function(textPieces) {
       this.assertReady_('setText');
     if (this.monaco_) {
-      return this.monaco_.getModel().setValue(textPieces);
+      return this.editorAdapter_.setValue(textPieces);
     } else if (this.ace_) {
       return this.ace_.getSession().getDocument().setValue(textPieces);
     } else {

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -141,6 +141,23 @@ var MonacoAdapter = function () {
   }
 
   /**
+   * @method setValue - Set editor value
+   * @param {string} - The text to set
+   */
+  MonacoAdapter.prototype.setValue = function(text) {
+    const model = this.getModel();
+
+    if (!model) {
+      return;
+    }
+
+    model.applyEdits([{
+      range: model.getFullModelRange(),
+      text,
+    }]);
+  }
+
+  /**
    * @method getCursor - Get current cursor position
    * @returns Firepad Cursor object
    */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firepad-x",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "1.5.18",
+  "version": "1.5.19",
   "author": "Firebase (https://firebase.google.com/)",
   "contributors": [
     "Michael Lehenbauer <michael@firebase.com>"


### PR DESCRIPTION
* Applies text as a change instead of full reset
  (to avoid cross browser/os sync issue)

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
