### PR TITLE
[Feat] Editor Client: Add Undo and Redo Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v1.5.22 [#17](https://github.com/interviewstreet/firepad-x/pull/17)
+  ### Improvements -
+  - Added Undo annd Redo event to EditorClient to assign event listener.
+
+  ### Changes -
+  - Moved Firebase into peer dependency.
+
 ## v1.5.21 [#16](https://github.com/interviewstreet/firepad-x/pull/16)
   ### Fixes -
   - Downgrade Firebase to 7.12 to avoid issues with Database.
@@ -7,6 +14,7 @@
 ## v1.5.20 [#15](https://github.com/interviewstreet/firepad-x/pull/15)
   ### Fixes -
   - Model Change Evennt Hanndling when no Model Content has changed.
+
   ### Improvements -
   - Move `jsdom` to devDependency of the project.
   - Improve build step to optimize output chunk.

--- a/lib/editor-client.js
+++ b/lib/editor-client.js
@@ -122,13 +122,19 @@ firepad.EditorClient = (function () {
   EditorClient.prototype.undo = function () {
     var self = this;
     if (!this.undoManager.canUndo()) { return; }
-    this.undoManager.performUndo(function (o) { self.applyUnredo(o); });
+    this.undoManager.performUndo(function (operation) {
+      self.trigger('undo', operation.toString());
+      self.applyUnredo(operation);
+    });
   };
 
   EditorClient.prototype.redo = function () {
     var self = this;
     if (!this.undoManager.canRedo()) { return; }
-    this.undoManager.performRedo(function (o) { self.applyUnredo(o); });
+    this.undoManager.performRedo(function (operation) {
+      self.trigger('redo', operation.toString());
+      self.applyUnredo(operation);
+    });
   };
 
   EditorClient.prototype.onChange = function (textOperation, inverse) {
@@ -200,4 +206,4 @@ firepad.EditorClient = (function () {
   return EditorClient;
 }());
 
-firepad.utils.makeEventEmitter(firepad.EditorClient, ['synced']);
+firepad.utils.makeEventEmitter(firepad.EditorClient, ['synced', 'undo', 'redo']);

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -139,6 +139,8 @@ firepad.Firepad = (function(global) {
     });
 
     this.client_.on('synced', function(isSynced) { self.trigger('synced', isSynced)} );
+    this.client_.on('undo', function(undoOperation) { self.trigger('undo', undoOperation)} );
+    this.client_.on('redo', function(redoOperation) { self.trigger('redo', redoOperation)} );
 
     // Hack for IE8 to make font icons work more reliably.
     // http://stackoverflow.com/questions/9809351/ie8-css-font-face-fonts-only-working-for-before-content-on-over-and-sometimes

--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -378,7 +378,7 @@ var MonacoAdapter = function () {
   MonacoAdapter.prototype.onModelChange = function onModelChange(event) {
     const newModel = this.getModel();
 
-    if (!newModel || !newModel.getValue()) {
+    if (!newModel) {
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firepad-x",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "1.5.21",
+  "version": "1.5.22",
   "author": "Firebase (https://firebase.google.com/)",
   "contributors": [
     "Michael Lehenbauer <michael@firebase.com>"
@@ -39,7 +39,7 @@
     "package.json",
     "yarn.lock"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "firebase": "7.12.0"
   },
   "devDependencies": {
@@ -47,6 +47,7 @@
     "@babel/preset-env": "^7.7.1",
     "codemirror": "^5.50.2",
     "coveralls": "^3.0.2",
+    "firebase": "7.12.0",
     "grunt": "^1.1.0",
     "grunt-babel": "^8.0.0",
     "grunt-cli": "^1.3.1",


### PR DESCRIPTION
Expose Editor Client Undo/Redo operation from Firepad, so that consuming modules can assign their own event listener for the same.

Signed-off-by: Progyan Bhattacharya <bprogyan@gmail.com>

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
