### PR TITLE
[Fix] Editor Client: Move Cursor after Set Text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+## v1.5.23 [#18](https://github.com/interviewstreet/firepad-x/pull/18)
+  ### Fixes -
+  - Stop selecting text after first initialisation. Move cursor to begining after `setText` call.
 
 ## v1.5.22 [#17](https://github.com/interviewstreet/firepad-x/pull/17)
   ### Improvements -

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -214,9 +214,9 @@ firepad.Firepad = (function(global) {
   };
 
   Firepad.prototype.setText = function(textPieces) {
-      this.assertReady_('setText');
+    this.assertReady_('setText');
     if (this.monaco_) {
-      return this.editorAdapter_.setValue(textPieces);
+      this.editorAdapter_.setValue(textPieces);
     } else if (this.ace_) {
       return this.ace_.getSession().getDocument().setValue(textPieces);
     } else {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firepad-x",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "1.5.22",
+  "version": "1.5.23",
   "author": "Firebase (https://firebase.google.com/)",
   "contributors": [
     "Michael Lehenbauer <michael@firebase.com>"


### PR DESCRIPTION
Stop selecting text after first initialisation. Move cursor to begining after `setText` call.

Signed-off-by: Progyan Bhattacharya <bprogyan@gmail.com>

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
