### PR TITLE
[Fix] Editor Client: Send Stringfied Operation on Undo/Redo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## v1.5.24 [#19](https://github.com/interviewstreet/firepad-x/pull/19)
+  ### Fixes -
+  - Send actual operation in strigified version on event-bus for `undo` and `redo` operation.
+
 ## v1.5.23 [#18](https://github.com/interviewstreet/firepad-x/pull/18)
   ### Fixes -
   - Stop selecting text after first initialisation. Move cursor to begining after `setText` call.

--- a/lib/editor-client.js
+++ b/lib/editor-client.js
@@ -123,7 +123,7 @@ firepad.EditorClient = (function () {
     var self = this;
     if (!this.undoManager.canUndo()) { return; }
     this.undoManager.performUndo(function (operation) {
-      self.trigger('undo', operation.toString());
+      self.trigger('undo', operation.wrapped.toString());
       self.applyUnredo(operation);
     });
   };
@@ -132,7 +132,7 @@ firepad.EditorClient = (function () {
     var self = this;
     if (!this.undoManager.canRedo()) { return; }
     this.undoManager.performRedo(function (operation) {
-      self.trigger('redo', operation.toString());
+      self.trigger('redo', operation.wrapped.toString());
       self.applyUnredo(operation);
     });
   };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firepad-x",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "1.5.23",
+  "version": "1.5.24",
   "author": "Firebase (https://firebase.google.com/)",
   "contributors": [
     "Michael Lehenbauer <michael@firebase.com>"


### PR DESCRIPTION
[Object object] was being instead of actual operation.
Signed-off-by: Progyan Bhattacharya <bprogyan@gmail.com>

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
