### PR TITLE
[Fix] Operation: Remove Validation Rule for User ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## v1.5.25 [#20](https://github.com/interviewstreet/firepad-x/pull/20)
+  ### Fixes -
+  - Remove Data Type Validation for Operation Actor (`op.a`) so that number can used as User ID.
+
 ## v1.5.24 [#19](https://github.com/interviewstreet/firepad-x/pull/19)
   ### Fixes -
   - Send actual operation in strigified version on event-bus for `undo` and `redo` operation.

--- a/lib/firebase-adapter.js
+++ b/lib/firebase-adapter.js
@@ -321,8 +321,7 @@ firepad.FirebaseAdapter = (function (global) {
 
   FirebaseAdapter.prototype.parseRevision_ = function(data) {
     // We could do some of this validation via security rules.  But it's nice to be robust, just in case.
-    if (typeof data !== 'object') { return null; }
-    if (typeof data.a !== 'string' || typeof data.o !== 'object') { return null; }
+    if (typeof data !== 'object' || typeof data.o !== 'object') { return null; }
     var op = null;
     try {
       op = TextOperation.fromJSON(data.o);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firepad-x",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "1.5.24",
+  "version": "1.5.25",
   "author": "Firebase (https://firebase.google.com/)",
   "contributors": [
     "Michael Lehenbauer <michael@firebase.com>"


### PR DESCRIPTION
Number can be used as User Id and hence as actor of operation.

Signed-off-by: Progyan Bhattacharya <bprogyan@gmail.com>

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
