### PR TITLE
[Fix] Cursor: Add Null checks before accessing properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.5.28 [#22](https://github.com/interviewstreet/firepad-x/pull/22)
+  ### Fixes -
+  - More `null` check for cursor before invoking `equals` method.
+
 ## v1.5.27
   ### Fixes -
   - Add `null` check for cursor before invoking `equals` method.

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -16,6 +16,10 @@ firepad.Cursor = (function () {
   };
 
   Cursor.prototype.equals = function (other) {
+    if (other === null) {
+      return false;
+    }
+
     return this.position === other.position &&
       this.selectionEnd === other.selectionEnd;
   };

--- a/lib/editor-client.js
+++ b/lib/editor-client.js
@@ -155,7 +155,17 @@ firepad.EditorClient = (function () {
   EditorClient.prototype.onCursorActivity = function () {
     var oldCursor = this.cursor;
     this.updateCursor();
-    if (oldCursor && this.cursor && this.cursor.equals(oldCursor) && !!oldCursor.synced) { return; }
+
+    if (oldCursor === null && oldCursor === this.cursor) {
+      /** Empty Cursor */
+      return;
+    }
+
+    if (oldCursor && this.cursor && this.cursor.equals(oldCursor) && oldCursor.synced === true) {
+      /** Already synced Cursor */
+      return;
+    }
+
     this.sendCursor(this.cursor);
   };
 
@@ -173,16 +183,22 @@ firepad.EditorClient = (function () {
   EditorClient.prototype.sendCursor = function (cursor) {
     var self = this;
 
+    if (this._sendCursorTimeout) {
+      clearTimeout(this._sendCursorTimeout);
+    }
+
     if (this.state instanceof Client.AwaitingWithBuffer) {
-      setTimeout(function () {
+      this._sendCursorTimeout = setTimeout(function () {
         self.sendCursor(cursor);
       }, 1);
       return;
     }
 
-    this.serverAdapter.sendCursor(cursor, function () {
-      if (cursor && self.cursor.equals(cursor)) {
-        self.cursor.synced = true;
+    this.serverAdapter.sendCursor(cursor, function (err, syncedCursor) {
+      if (err) { return self.trigger('error', err); }
+
+      if (syncedCursor) {
+        syncedCursor.synced = true;
       }
     });
   };
@@ -218,4 +234,4 @@ firepad.EditorClient = (function () {
   return EditorClient;
 }());
 
-firepad.utils.makeEventEmitter(firepad.EditorClient, ['synced', 'undo', 'redo']);
+firepad.utils.makeEventEmitter(firepad.EditorClient, ['synced', 'undo', 'redo', 'error']);

--- a/lib/firebase-adapter.js
+++ b/lib/firebase-adapter.js
@@ -76,13 +76,8 @@ firepad.FirebaseAdapter = (function (global) {
       return;
     }
 
-    if (this.userRef_) {
-      this.userRef_ = null;
-    //   this.userRef_.child('cursor').remove();
-    //   this.userRef_.child('color').remove();
-    }
-
     this.ref_ = null;
+    this.userRef_ = null;
     this.document_ = null;
     this.zombie_ = true;
   };
@@ -169,16 +164,18 @@ firepad.FirebaseAdapter = (function (global) {
     doTransaction(revisionId, { a: self.userId_, o: operation.toJSON(), t: firebase.database.ServerValue.TIMESTAMP });
   };
 
-  FirebaseAdapter.prototype.sendCursor = function (cursor, onSuccess) {
+  FirebaseAdapter.prototype.sendCursor = function (cursor, callback) {
+    if (!this.userRef_) { return; }
     this.userRef_.child('cursor').set(cursor, function (error) {
-      if (!error && typeof onSuccess === 'function') {
-        onSuccess();
+      if (typeof callback === 'function') {
+        callback(error, cursor);
       }
     });
     this.cursor_ = cursor;
   };
 
   FirebaseAdapter.prototype.setColor = function(color) {
+    if (!this.userRef_) { return; }
     this.userRef_.child('color').set(color);
     this.color_ = color;
   };
@@ -205,6 +202,7 @@ firepad.FirebaseAdapter = (function (global) {
     var usersRef = this.ref_.child('users'), self = this;
 
     function childChanged(childSnap) {
+      if (self.zombie_) { return; } // just in case we were cleaned up before we got the checkpoint data.
       var userId = childSnap.key;
       var userData = childSnap.val();
       self.trigger('cursor', userId, userData.cursor, userData.color);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firepad-x",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "1.5.27",
+  "version": "1.5.28",
   "author": "Firebase (https://firebase.google.com/)",
   "contributors": [
     "Michael Lehenbauer <michael@firebase.com>"


### PR DESCRIPTION
Uglifier emits optimized code that avoid short-circtuis that check for null values.

Signed-off-by: Progyan Bhattacharya <bprogyan@gmail.com>

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
