### PR TITLE
(fix) Monaco Adapter: Fix EOL Reset in Monaco Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Good to have: commit or PR links.
 
 -->
 
+## v0.1.1 - [#30](https://github.com/interviewstreet/firepad-x/pull/24)
+
+### Fixes
+
+- EOL Reset in Monaco Model content due to `setValue` call in `setInitiated` method, changed it to use existing `setText` call in Monaco Adapter.
+
 ## v0.1.0 - [#24](https://github.com/interviewstreet/firepad-x/pull/24)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hackerrank/firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "email": "bprogyan@gmail.com",
     "name": "Progyan Bhattacharya",

--- a/src/monaco-adapter.ts
+++ b/src/monaco-adapter.ts
@@ -397,7 +397,8 @@ export class MonacoAdapter implements IEditorAdapter {
   }
 
   setInitiated(init: boolean): void {
-    this._monaco.setValue(""); // Perfomance boost on clearing editor after network calls
+    // Perfomance boost on clearing editor after network calls (do not directly setValue or EOL will get reset and break sync)
+    this.setText("");
     this._initiated = init;
   }
 


### PR DESCRIPTION
Remove setValue call in setIntiated method in Monaco Adapter, replaced with it's own setText method.

Signed-off-by: Progyan Bhattacharya <bprogyan@gmail.com>

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
