### PR TITLE
feat: Added option to allow disable and enable firepad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ Good to have: commit or PR links.
 
 -->
 
+## v0.4.2-beta [#55](https://github.com/interviewstreet/firepad-x/pull/55)
+
+### Changed
+
+- Added `Firepd.enable()` and `Firepad.disable()` API methods for enbling and disabling firepad without disposing.
+- No breaking changes on the API level.
+
 ## v0.4.1-beta
 
 No Changes
@@ -30,11 +37,11 @@ No Changes
 
 ### Changed
 
-- Fix a bug monaco-adapter/_operationFromMonacoChange function
+- Fix a bug monaco-adapter/\_operationFromMonacoChange function
 - Revert https://github.com/interviewstreet/firepad-x/commit/2aebf79871d3fc9bf21e9b056a0faa60c6da0b3a
 - Revert https://github.com/interviewstreet/firepad-x/commit/a12177892c692b44c106d60f2819fbf7f1094f22
 - No breaking change on external APIs.
-- Revert to firebase v7.12.0 (https://github.com/interviewstreet/firepad-x/commit/03910ce475e04ddcab2e683877f579bfcbd32d91). 
+- Revert to firebase v7.12.0 (https://github.com/interviewstreet/firepad-x/commit/03910ce475e04ddcab2e683877f579bfcbd32d91).
 
 ## v0.3.1 [#44](https://github.com/interviewstreet/firepad-x/pull/44)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hackerrank/firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.4.1-beta",
+  "version": "0.4.1-alpha.1",
   "author": {
     "email": "bprogyan@gmail.com",
     "name": "Progyan Bhattacharya",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hackerrank/firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.4.1-alpha.1",
+  "version": "0.4.1-alpha.2",
   "author": {
     "email": "bprogyan@gmail.com",
     "name": "Progyan Bhattacharya",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hackerrank/firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.4.1-alpha.2",
+  "version": "0.4.1-alpha.3",
   "author": {
     "email": "bprogyan@gmail.com",
     "name": "Progyan Bhattacharya",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hackerrank/firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.4.1-alpha.4",
+  "version": "0.4.2-beta",
   "author": {
     "email": "bprogyan@gmail.com",
     "name": "Progyan Bhattacharya",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hackerrank/firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.4.1-alpha.test.3",
+  "version": "0.4.1-alpha.4",
   "author": {
     "email": "bprogyan@gmail.com",
     "name": "Progyan Bhattacharya",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hackerrank/firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.4.1-alpha.3",
+  "version": "0.4.1-alpha.test.3",
   "author": {
     "email": "bprogyan@gmail.com",
     "name": "Progyan Bhattacharya",

--- a/src/firebase-adapter.ts
+++ b/src/firebase-adapter.ts
@@ -156,6 +156,14 @@ export class FirebaseAdapter implements IDatabaseAdapter {
     this._init();
   }
 
+  public enable() {
+    this._zombie = false;
+  }
+
+  public disable() {
+    this._zombie = true;
+  }
+
   protected _init(): void {
     const connectedRef = this._databaseRef!.root.child(".info/connected");
 

--- a/src/firepad-classic.ts
+++ b/src/firepad-classic.ts
@@ -95,8 +95,25 @@ export default class FirepadClassic implements IFirepad {
     this.init();
   }
 
-  public enable(): void {}
-  public disable(): void {}
+  public enable(): void {
+    throw new Error("Method not implemented.");
+  }
+
+  public disable(): void {
+    throw new Error("Method not implemented.");
+  }
+
+  public beforeApplyChanges(
+    callback: (changes: monaco.editor.IIdentifiedSingleEditOperation[]) => void
+  ): void {
+    throw new Error("Method not implemented.");
+  }
+
+  public afterApplyChanges(
+    callback: (changes: monaco.editor.IIdentifiedSingleEditOperation[]) => void
+  ): void {
+    throw new Error("Method not implemented.");
+  }
 
   protected init(): void {
     this._databaseAdapter.on(DatabaseAdapterEvent.Ready, () => {

--- a/src/firepad-classic.ts
+++ b/src/firepad-classic.ts
@@ -95,6 +95,9 @@ export default class FirepadClassic implements IFirepad {
     this.init();
   }
 
+  public enable(): void {}
+  public disable(): void {}
+
   protected init(): void {
     this._databaseAdapter.on(DatabaseAdapterEvent.Ready, () => {
       this._ready = true;

--- a/src/firepad.ts
+++ b/src/firepad.ts
@@ -13,6 +13,8 @@ import {
   IEditorClientEvent,
 } from "./editor-client";
 import { EventEmitter, EventListenerType, IEventEmitter } from "./emitter";
+import { FirebaseAdapter } from "./firebase-adapter";
+import { MonacoAdapter } from "./monaco-adapter";
 import * as Utils from "./utils";
 
 export enum FirepadEvent {
@@ -102,13 +104,21 @@ export interface IFirepad extends Utils.IDisposable {
    * @param option - Configuration option (same as constructor).
    */
   getConfiguration(option: keyof IFirepadConstructorOptions): any;
+  /**
+   *Enable firepad if it is disabled.
+   */
+  enable(): void;
+  /**
+   * Disable firepad without destroying it.
+   */
+  disable(): void;
 }
 
 export class Firepad implements IFirepad {
   protected readonly _options: IFirepadConstructorOptions;
   protected readonly _editorClient: IEditorClient;
-  protected readonly _editorAdapter: IEditorAdapter;
-  protected readonly _databaseAdapter: IDatabaseAdapter;
+  protected readonly _editorAdapter: MonacoAdapter;
+  protected readonly _databaseAdapter: FirebaseAdapter;
 
   protected _ready: boolean;
   protected _zombie: boolean;
@@ -134,8 +144,8 @@ export class Firepad implements IFirepad {
     this._zombie = false;
     this._options = options;
 
-    this._databaseAdapter = databaseAdapter;
-    this._editorAdapter = editorAdapter;
+    this._databaseAdapter = databaseAdapter as FirebaseAdapter;
+    this._editorAdapter = editorAdapter as MonacoAdapter;
     this._editorClient = new EditorClient(databaseAdapter, editorAdapter);
 
     this._emitter = new EventEmitter([
@@ -201,6 +211,18 @@ export class Firepad implements IFirepad {
         });
       }
     );
+  }
+
+  public enable() {
+    this._databaseAdapter.enable();
+    //for text changes
+    this._editorAdapter.enable();
+  }
+
+  public disable() {
+    console.log("disable");
+    this._databaseAdapter.disable();
+    this._editorAdapter.disable();
   }
 
   getConfiguration(option: keyof IFirepadConstructorOptions): any {
@@ -292,7 +314,7 @@ export class Firepad implements IFirepad {
     );
     Utils.validateFalse(
       this._zombie,
-      `You can't use a Firepad after calling dispose()!  [called ${func}]`
+      `You can"t use a Firepad after calling dispose()!  [called ${func}]`
     );
   }
 }

--- a/src/firepad.ts
+++ b/src/firepad.ts
@@ -1,3 +1,4 @@
+import { editor } from "monaco-editor";
 import { Cursor } from "./cursor";
 import {
   DatabaseAdapterEvent,
@@ -112,6 +113,14 @@ export interface IFirepad extends Utils.IDisposable {
    * Disable firepad without destroying it.
    */
   disable(): void;
+
+  beforeApplyChanges(
+    callback: (changes: editor.IIdentifiedSingleEditOperation[]) => void
+  ): void;
+
+  afterApplyChanges(
+    callback: (changes: editor.IIdentifiedSingleEditOperation[]) => void
+  ): void;
 }
 
 export class Firepad implements IFirepad {
@@ -221,6 +230,18 @@ export class Firepad implements IFirepad {
   public disable() {
     this._databaseAdapter.disable();
     this._editorAdapter.disable();
+  }
+
+  public beforeApplyChanges(
+    callback: (changes: editor.IIdentifiedSingleEditOperation[]) => void
+  ) {
+    this._editorAdapter.beforeApplyChanges(callback);
+  }
+
+  public afterApplyChanges(
+    callback: (changes: editor.IIdentifiedSingleEditOperation[]) => void
+  ) {
+    this._editorAdapter.afterApplyChanges(callback);
   }
 
   getConfiguration(option: keyof IFirepadConstructorOptions): any {

--- a/src/firepad.ts
+++ b/src/firepad.ts
@@ -215,12 +215,10 @@ export class Firepad implements IFirepad {
 
   public enable() {
     this._databaseAdapter.enable();
-    //for text changes
     this._editorAdapter.enable();
   }
 
   public disable() {
-    console.log("disable");
     this._databaseAdapter.disable();
     this._editorAdapter.disable();
   }
@@ -314,7 +312,7 @@ export class Firepad implements IFirepad {
     );
     Utils.validateFalse(
       this._zombie,
-      `You can"t use a Firepad after calling dispose()!  [called ${func}]`
+      `You can't use a Firepad after calling dispose()!  [called ${func}]`
     );
   }
 }

--- a/src/monaco-adapter.ts
+++ b/src/monaco-adapter.ts
@@ -1,5 +1,4 @@
 import * as monaco from "monaco-editor";
-
 import { Cursor, ICursor } from "./cursor";
 import {
   CursorWidgetController,

--- a/src/monaco-adapter.ts
+++ b/src/monaco-adapter.ts
@@ -91,32 +91,6 @@ export class MonacoAdapter implements IEditorAdapter {
     this._disposables.splice(0, this._disposables.length);
   }
 
-  deregisterUndo(callback?: any): void {
-    const model = this._getModel();
-    if (!model) {
-      return;
-    }
-
-    if (model.undo !== this._originalUndo) {
-      model.undo = this._originalUndo;
-    }
-
-    this._originalUndo = null;
-  }
-
-  deregisterRedo(callback?: any): void {
-    const model = this._getModel();
-    if (!model) {
-      return;
-    }
-
-    if (model.redo !== this._originalRedo) {
-      model.redo = this._originalRedo;
-    }
-
-    this._originalRedo = null;
-  }
-
   protected _init(): void {
     this._emitter = new EventEmitter([
       EditorAdapterEvent.Blur,

--- a/src/monaco-adapter.ts
+++ b/src/monaco-adapter.ts
@@ -27,6 +27,8 @@ interface ITextModelWithUndoRedo extends monaco.editor.ITextModel {
   redo: UndoRedoCallbackType | null;
 }
 
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 export class MonacoAdapter implements IEditorAdapter {
   protected readonly _monaco: monaco.editor.IStandaloneCodeEditor;
   protected readonly _classNames: string[];
@@ -101,6 +103,7 @@ export class MonacoAdapter implements IEditorAdapter {
     this._ignoreChanges = false;
     this._initMonacoEvents();
     this.operationsToBeApplied.forEach(async (operation) => {
+      await wait(0);
       await this.applyOperation(operation);
     });
     this.operationsToBeApplied = [];

--- a/src/monaco-adapter.ts
+++ b/src/monaco-adapter.ts
@@ -100,8 +100,8 @@ export class MonacoAdapter implements IEditorAdapter {
     this._isDisabled = false;
     this._ignoreChanges = false;
     this._initMonacoEvents();
-    this.operationsToBeApplied.forEach((operation) => {
-      this.applyOperation(operation);
+    this.operationsToBeApplied.forEach(async (operation) => {
+      await this.applyOperation(operation);
     });
     this.operationsToBeApplied = [];
   }


### PR DESCRIPTION
# Why?
In vscode, the editor instance is the same across multiple files. i.e. whenever a user opens a file, instead of creating a new Editor instance, vscode changes the model of the existing opened editor. So after creating the multiple firepad instances on the same editor instance, a code duplication issue occurs. 

To avoid a code duplication issue, we tried a workaround where firepad is disposed and created again for every tab switch or file open.  but that will destroy undo/redo history.

So, if we could provide we disable and enable firepad functionalities we can make it work for vscode.

# What
With this Firepad will have the below 2 APIs for the above workaround. It is backward compatible, no code changes are required after the update. 

```js
Firepad.enable()
Firepad.disable()

```



