### PR TITLE
Create monaco and vscode editor bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Tags:
 Good to have: commit or PR links.
 
 -->
+## v0.5.2-beta [#56](https://github.com/interviewstreet/firepad-x/pull/56)
+
+### Changed
+
+- Added MonacoEditorUtilAdapter to support native monaco and monaco from vscode
 
 ## v0.4.2-beta [#55](https://github.com/interviewstreet/firepad-x/pull/55)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hackerrank/firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.4.2-beta",
+  "version": "0.5.2-beta",
   "author": {
     "email": "bprogyan@gmail.com",
     "name": "Progyan Bhattacharya",

--- a/src/cursor-widget-controller.ts
+++ b/src/cursor-widget-controller.ts
@@ -2,6 +2,7 @@ import * as monaco from "monaco-editor";
 
 import { CursorWidget, ICursorWidget } from "./cursor-widget";
 import { ClientIDType } from "./editor-adapter";
+import { IMonacoEditorUtilsAdapter } from "./monaco-editor-utils";
 import { IDisposable } from "./utils";
 
 export interface ICursorWidgetController extends IDisposable {
@@ -42,11 +43,13 @@ export class CursorWidgetController implements ICursorWidgetController {
   protected readonly _cursors: Map<ClientIDType, ICursorWidget>;
   protected readonly _editor: monaco.editor.IStandaloneCodeEditor;
   protected readonly _tooltipDuration: number;
+  protected readonly _editorUtils: IMonacoEditorUtilsAdapter;
 
-  constructor(editor: monaco.editor.IStandaloneCodeEditor) {
+  constructor(editor: monaco.editor.IStandaloneCodeEditor, editorUtils: IMonacoEditorUtilsAdapter) {
     this._editor = editor;
     this._tooltipDuration = 1000;
     this._cursors = new Map<ClientIDType, ICursorWidget>();
+    this._editorUtils = editorUtils;
   }
 
   addCursor(
@@ -62,6 +65,7 @@ export class CursorWidgetController implements ICursorWidgetController {
       range,
       label: userName || clientId.toString(),
       tooltipDuration: this._tooltipDuration,
+      editorUtils: this._editorUtils,
       onDisposed: () => {
         this.removeCursor(clientId);
       },

--- a/src/cursor-widget.ts
+++ b/src/cursor-widget.ts
@@ -10,6 +10,7 @@
 import * as monaco from "monaco-editor";
 
 import { ClientIDType } from "./editor-adapter";
+import { IMonacoEditorUtilsAdapter } from "./monaco-editor-utils";
 import * as Utils from "./utils";
 
 type OnDisposed = Utils.VoidFunctionType;
@@ -22,6 +23,7 @@ export interface ICursorWidgetConstructorOptions {
   range: monaco.Range;
   tooltipDuration?: number;
   opacity?: string;
+  editorUtils: IMonacoEditorUtilsAdapter;
   onDisposed: OnDisposed;
 }
 
@@ -56,6 +58,7 @@ export class CursorWidget implements ICursorWidget {
   protected readonly _tooltipDuration: number;
   protected readonly _scrollListener: monaco.IDisposable | null;
   protected readonly _onDisposed: OnDisposed;
+  protected readonly _editorUtils: IMonacoEditorUtilsAdapter;
 
   protected _tooltipNode: HTMLElement;
   protected _color: string;
@@ -76,7 +79,8 @@ export class CursorWidget implements ICursorWidget {
     range,
     tooltipDuration = 1000,
     opacity = "1.0",
-    onDisposed,
+    editorUtils,
+    onDisposed
   }: ICursorWidgetConstructorOptions) {
     this._editor = codeEditor;
     this._tooltipDuration = tooltipDuration;
@@ -85,6 +89,7 @@ export class CursorWidget implements ICursorWidget {
     this._color = color;
     this._content = label;
     this._opacity = opacity;
+    this._editorUtils = editorUtils;
 
     this._domNode = this._createWidgetNode();
 
@@ -148,8 +153,8 @@ export class CursorWidget implements ICursorWidget {
     this._position = {
       position: range.getEndPosition(),
       preference: [
-        monaco.editor.ContentWidgetPositionPreference.ABOVE,
-        monaco.editor.ContentWidgetPositionPreference.BELOW,
+        this._editorUtils.getContentWidgetPositionPreference('ABOVE'),
+        this._editorUtils.getContentWidgetPositionPreference('BELOW'),
       ],
     };
 

--- a/src/firepad-monaco.ts
+++ b/src/firepad-monaco.ts
@@ -5,6 +5,7 @@ import { UserIDType } from "./database-adapter";
 import { FirebaseAdapter } from "./firebase-adapter";
 import { Firepad, IFirepad, IFirepadConstructorOptions } from "./firepad";
 import { MonacoAdapter } from "./monaco-adapter";
+import { IMonacoEditorUtilsAdapter, NativeMonacoEditorUtils } from "./monaco-editor-utils";
 import * as Utils from "./utils";
 
 /**
@@ -16,7 +17,8 @@ import * as Utils from "./utils";
 export function fromMonaco(
   databaseRef: string | firebase.database.Reference,
   editor: monaco.editor.IStandaloneCodeEditor,
-  options: Partial<IFirepadConstructorOptions> = {}
+  options: Partial<IFirepadConstructorOptions> = {},
+  editorUtils: IMonacoEditorUtilsAdapter = new NativeMonacoEditorUtils()
 ): IFirepad {
   // Initialize constructor options with their default values
   const userId: UserIDType = options.userId || uuid();
@@ -31,7 +33,7 @@ export function fromMonaco(
     userColor,
     userName
   );
-  const editorAdapter = new MonacoAdapter(editor, false);
+  const editorAdapter = new MonacoAdapter(editor, false, editorUtils);
 
   return new Firepad(databaseAdapter, editorAdapter, {
     userId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export * from "./firepad";
 export * from "./firepad-monaco";
 export * from "./monaco-adapter";
 export * from "./text-operation";
+export * from "./monaco-editor-utils";
 
 export { Firepad as default } from "./firepad";

--- a/src/monaco-adapter.ts
+++ b/src/monaco-adapter.ts
@@ -14,6 +14,7 @@ import {
   UndoRedoCallbackType,
 } from "./editor-adapter";
 import { EventEmitter, EventListenerType, IEventEmitter } from "./emitter";
+import { IMonacoEditorUtilsAdapter, NativeMonacoEditorUtils } from "./monaco-editor-utils";
 import { ITextOp } from "./text-op";
 import { ITextOperation, TextOperation } from "./text-operation";
 import * as Utils from "./utils";
@@ -34,6 +35,7 @@ export class MonacoAdapter implements IEditorAdapter {
   protected readonly _disposables: monaco.IDisposable[];
   protected readonly _remoteCursors: Map<ClientIDType, IRemoteCursor>;
   protected readonly _cursorWidgetController: ICursorWidgetController;
+  protected readonly _editorUtils: IMonacoEditorUtilsAdapter;
 
   protected _ignoreChanges: boolean;
   protected _lastDocLines: string[];
@@ -52,7 +54,8 @@ export class MonacoAdapter implements IEditorAdapter {
    */
   constructor(
     monacoInstance: monaco.editor.IStandaloneCodeEditor,
-    avoidListeners: boolean = true
+    avoidListeners: boolean = true,
+    editorUtils: IMonacoEditorUtilsAdapter = new NativeMonacoEditorUtils()
   ) {
     this._classNames = [];
     this._disposables = [];
@@ -60,7 +63,8 @@ export class MonacoAdapter implements IEditorAdapter {
     this._lastDocLines = this._monaco.getModel()?.getLinesContent() || [""];
     this._lastCursorRange = this._monaco.getSelection();
     this._remoteCursors = new Map<ClientIDType, IRemoteCursor>();
-    this._cursorWidgetController = new CursorWidgetController(this._monaco);
+    this._editorUtils = editorUtils;
+    this._cursorWidgetController = new CursorWidgetController(this._monaco, editorUtils);
 
     this._redoCallback = null;
     this._undoCallback = null;
@@ -244,7 +248,7 @@ export class MonacoAdapter implements IEditorAdapter {
 
     /** Create Selection in the Editor */
     this._monaco.setSelection(
-      new monaco.Range(
+      new this._editorUtils.Range(
         start.lineNumber,
         start.column,
         end.lineNumber,
@@ -320,7 +324,7 @@ export class MonacoAdapter implements IEditorAdapter {
     }
 
     /** Find Range of Selection */
-    const range = new monaco.Range(
+    const range = new this._editorUtils.Range(
       start.lineNumber,
       start.column,
       end.lineNumber,
@@ -337,7 +341,7 @@ export class MonacoAdapter implements IEditorAdapter {
             className,
             isWholeLine: false,
             stickiness:
-              monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+              this._editorUtils.getTrackedRangeStickiness('NeverGrowsWhenTypingAtEdges'),
           },
         },
       ]
@@ -464,7 +468,7 @@ export class MonacoAdapter implements IEditorAdapter {
         /** Insert Operation */
         const pos = model.getPositionAt(index);
         changes.push({
-          range: new monaco.Range(
+          range: new this._editorUtils.Range(
             pos.lineNumber,
             pos.column,
             pos.lineNumber,
@@ -482,7 +486,7 @@ export class MonacoAdapter implements IEditorAdapter {
         const to = model.getPositionAt(index + op.chars!);
 
         changes.push({
-          range: new monaco.Range(
+          range: new this._editorUtils.Range(
             from.lineNumber,
             from.column,
             to.lineNumber,
@@ -513,7 +517,7 @@ export class MonacoAdapter implements IEditorAdapter {
       ({ readOnly } = this._monaco.getConfiguration());
     } else {
       // @ts-ignore - Remove this after monaco upgrade
-      readOnly = this._monaco.getOption(monaco.editor.EditorOption.readOnly);
+      readOnly = this._monaco.getOption(this._editorUtils.getEditorOption('readOnly'));
     }
 
     if (readOnly) {
@@ -575,7 +579,7 @@ export class MonacoAdapter implements IEditorAdapter {
   protected _onCursorActivity(
     ev: monaco.editor.ICursorPositionChangedEvent
   ): void {
-    if (ev.reason === monaco.editor.CursorChangeReason.RecoverFromMarkers) {
+    if (ev.reason === this._editorUtils.getCursorChangeReason('RecoverFromMarkers')) {
       return;
     }
 
@@ -631,7 +635,7 @@ export class MonacoAdapter implements IEditorAdapter {
 
     const oldLinesCount = this._lastDocLines.length;
     const oldLastColumLength = this._lastDocLines[oldLinesCount - 1].length;
-    const oldRange = new monaco.Range(
+    const oldRange = new this._editorUtils.Range(
       1,
       1,
       oldLinesCount,

--- a/src/monaco-editor-utils.ts
+++ b/src/monaco-editor-utils.ts
@@ -1,5 +1,17 @@
 import * as monaco from "monaco-editor";
 
+/**
+ * Monaco editor is built from vscode source, If we use firepad-x in vscode
+ * we cannot add monaco-editor as a dependency as it will increase the bundle size
+ * and we are just adding duplicate code which already exists in vscode
+ * 
+ * So we have created a adapter which provides native monaco editor utils
+ * when used without vscode and when used with vscode the vscode consumer
+ * provide vscode specific editor utils
+ * 
+ * For a normal consumer of firepad this should make no difference as 
+ * NativeMonacoEditorUtils is used by default
+ */
 export interface IMonacoEditorUtilsAdapter {
   getTrackedRangeStickiness(option: keyof typeof monaco.editor.TrackedRangeStickiness): monaco.editor.TrackedRangeStickiness;
   getEditorOption(option: string): any;

--- a/src/monaco-editor-utils.ts
+++ b/src/monaco-editor-utils.ts
@@ -1,0 +1,30 @@
+import * as monaco from "monaco-editor";
+
+export interface IMonacoEditorUtilsAdapter {
+  getTrackedRangeStickiness(option: keyof typeof monaco.editor.TrackedRangeStickiness): monaco.editor.TrackedRangeStickiness;
+  getEditorOption(option: string): any;
+  getCursorChangeReason(option: keyof typeof monaco.editor.CursorChangeReason): monaco.editor.CursorChangeReason;
+  getContentWidgetPositionPreference(option: keyof typeof monaco.editor.ContentWidgetPositionPreference): monaco.editor.ContentWidgetPositionPreference;
+  Range: typeof monaco.Range;
+}
+
+export class NativeMonacoEditorUtils implements IMonacoEditorUtilsAdapter {
+  getTrackedRangeStickiness(option: keyof typeof monaco.editor.TrackedRangeStickiness): monaco.editor.TrackedRangeStickiness {
+    return monaco.editor.TrackedRangeStickiness[option];
+  }
+
+  getEditorOption(option: string) {
+    // @ts-ignore
+    return monaco.editor.EditorOption[option];
+  }
+
+  getCursorChangeReason(option: keyof typeof monaco.editor.CursorChangeReason): monaco.editor.CursorChangeReason {
+    return monaco.editor.CursorChangeReason[option];
+  }
+
+  getContentWidgetPositionPreference(option: keyof typeof monaco.editor.ContentWidgetPositionPreference): monaco.editor.ContentWidgetPositionPreference {
+    return monaco.editor.ContentWidgetPositionPreference[option];
+  }
+
+  Range = monaco.Range;
+}


### PR DESCRIPTION
 Monaco editor is built from vscode source, If we use firepad-x in vscode, we cannot add monaco-editor as a dependency as it will increase the bundle size and we are just adding duplicate code which already exists in vscode
  
So we have created a adapter which provides native monaco editor utils when used without vscode and when used with vscode the vscode consumer provide vscode specific editor utils
 
 For a normal consumer of firepad this should make no difference as NativeMonacoEditorUtils is used by default