### PR TITLE
Fix content duplication issue during firepad initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hackerrank/firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.5.3-alpha",
+  "version": "0.5.3-beta",
   "author": {
     "email": "bprogyan@gmail.com",
     "name": "Progyan Bhattacharya",
@@ -91,7 +91,7 @@
   },
   "scripts": {
     "prepare": "husky install",
-    "start": "webpack serve --hot --progress --mode development --port 9002 --host 0.0.0.0 --config configs/webpack.dev.config.js",
+    "start": "webpack serve --hot --progress --mode development --port 9000 --host 0.0.0.0 --config configs/webpack.dev.config.js",
     "start:prod": "webpack serve --hot --progress --mode production --port 9000 --host 0.0.0.0 --config configs/webpack.dev.config.js",
     "clean": "rimraf dist es lib types",
     "prebuild": "yarn clean",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hackerrank/firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.5.2-beta",
+  "version": "0.5.3-alpha",
   "author": {
     "email": "bprogyan@gmail.com",
     "name": "Progyan Bhattacharya",
@@ -91,7 +91,7 @@
   },
   "scripts": {
     "prepare": "husky install",
-    "start": "webpack serve --hot --progress --mode development --port 9000 --host 0.0.0.0 --config configs/webpack.dev.config.js",
+    "start": "webpack serve --hot --progress --mode development --port 9002 --host 0.0.0.0 --config configs/webpack.dev.config.js",
     "start:prod": "webpack serve --hot --progress --mode production --port 9000 --host 0.0.0.0 --config configs/webpack.dev.config.js",
     "clean": "rimraf dist es lib types",
     "prebuild": "yarn clean",

--- a/src/firebase-adapter.ts
+++ b/src/firebase-adapter.ts
@@ -401,7 +401,19 @@ export class FirebaseAdapter implements IDatabaseAdapter {
           // We have an outstanding change at this revision id.
           if (
             this._sent.op.equals(revision.operation) &&
-            revision.author == this._userId
+            /** 
+             * Adding the OR revisionId === "A0" condition because when firepad is
+             * initialized, both clients call Firepad.setText method which results
+             * in an operation being created for the default editor content of both the
+             * clients. If default editor content is same because of any code stub or
+             * if we have set some default value in monaco editor, this leads to the
+             * same default code appearing twice. To fix this, we make an assumption that
+             * if the sent op is same as received op and if it's the first op (A0), then
+             * it was probably a code stub. This condition will not hold true if both the
+             * clients input the same character after being initialized on purpose and want
+             * that content to be replicated twice. This however seems unlikely.
+            */
+            (revision.author == this._userId || revisionId === "A0")
           ) {
             // This is our change; it succeeded.
             if (this._revision % FirebaseAdapter.CHECKPOINT_FREQUENCY === 0) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
If firepad is initialized for two clients at the same time, and if these clients have a default content in their monaco editor, then this content is replicated twice for both the clients.
In the solution, we make the assumption that if the sent and received operation is same, and if its a first operation (A0), then it probably will lead to content duplication. This assumption can be wrong when the first operation for multiple clients is the same and it's intentional. With the current fix, if first operation is same, then it'll only be applied once.
<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
