### PR TITLE
feat: add console.error in all firestore catch blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hackerrank/firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.7.1-beta",
+  "version": "0.7.4-beta",
   "author": {
     "email": "bprogyan@gmail.com",
     "name": "Progyan Bhattacharya",

--- a/src/firestore-adapter.ts
+++ b/src/firestore-adapter.ts
@@ -302,7 +302,7 @@ export class FirestoreAdapter implements IDatabaseAdapter {
         }
       })
       .catch((error) => {
-        console.log("Error getting cached document:", error);
+        console.error("[firestore] Error getting checkpoint", error);
       });
   }
 
@@ -340,9 +340,14 @@ export class FirestoreAdapter implements IDatabaseAdapter {
       });
     });
 
-    historyRef.get().then(() => {
-      this._handleInitialRevisions();
-    });
+    historyRef
+      .get()
+      .then(() => {
+        this._handleInitialRevisions();
+      })
+      .catch((error) => {
+        console.error("[firestore] Error getting initial revisions", error);
+      });
   }
 
   /**
@@ -724,6 +729,8 @@ export class FirestoreAdapter implements IDatabaseAdapter {
         }
       })
       .catch((error) => {
+        console.error("[firestore] Error sending cursor", error);
+
         if (typeof callback === "function") {
           callback(error, cursor);
         }


### PR DESCRIPTION
### Description

Catch blocks in firestore adapter would log the error with console.log() which made it tough to separate when sending to error monitoring services like Sentry. Changing it to write errors with console.error() would help track the errors more easily.

### Code sample

No implementation changes.

### Console logs
<img width="960" alt="image" src="https://user-images.githubusercontent.com/17140551/225607822-50513486-c2e6-404f-8b23-5d1d0937d388.png">
