### PR TITLE
fix: content duplication during initialization in v0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hackerrank/firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.8.0-beta",
+  "version": "0.8.1-beta",
   "author": {
     "email": "bprogyan@gmail.com",
     "name": "Progyan Bhattacharya",

--- a/src/firebase-adapter.ts
+++ b/src/firebase-adapter.ts
@@ -393,7 +393,19 @@ export class FirebaseAdapter implements IDatabaseAdapter {
           // We have an outstanding change at this revision id.
           if (
             this._sent.op.equals(revision.operation) &&
-            revision.author == this._userId
+            /**
+             * Adding the OR revisionId === "A0" condition because when firepad is
+             * initialized, both clients call Firepad.setText method which results
+             * in an operation being created for the default editor content of both the
+             * clients. If default editor content is same because of any code stub or
+             * if we have set some default value in monaco editor, this leads to the
+             * same default code appearing twice. To fix this, we make an assumption that
+             * if the sent op is same as received op and if it's the first op (A0), then
+             * it was probably a code stub. This condition will not hold true if both the
+             * clients input the same character after being initialized on purpose and want
+             * that content to be replicated twice. This however seems unlikely.
+             */
+            (revision.author == this._userId || revisionId === "A0")
           ) {
             // This is our change; it succeeded.
             if (this._revision % FirebaseAdapter.CHECKPOINT_FREQUENCY === 0) {


### PR DESCRIPTION
### Description

A bug during firepad initialisation results in code duplication if both participants load the code at the same time the code would appear twice. This is a rare event, but it does happen.

Same as https://github.com/interviewstreet/firepad-x/pull/69