### PR TITLE
fix: v0.8.1-beta seems to published already, replacing with v0.8.2-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hackerrank/firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.8.1-beta",
+  "version": "0.8.2-beta",
   "author": {
     "email": "bprogyan@gmail.com",
     "name": "Progyan Bhattacharya",


### PR DESCRIPTION
The version 0.8.1-beta was not published because somehow the version already existed in npm repository, so republishing as 0.8.2-beta